### PR TITLE
create static batch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,3 @@ categories = ["web-programming", "wasm", "api-bindings"]
 wasm-bindgen = "0.2.83"
 web-sys = { version = "0.3.60", features = ["console", "Window", "Document", "Element", "HtmlElement", "HtmlHeadElement"] }
 js-sys = "0.3.60"
-
-[dependencies-dev]
-slab = "0.4.7"

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -66,11 +66,62 @@ pub(crate) enum Op {
     NoOp = 20,
 }
 
-pub struct FinalizedBatch {
-    pub(crate) msg: Vec<u8>,
-    pub(crate) str: Vec<u8>,
+/// A batch of operations ready to perform on the DOM.
+pub trait PreparedBatch {
+    fn msg(&self) -> &[u8];
+    fn str(&self) -> &[u8];
 }
 
+/// A batch of operations ready to perform on the DOM.
+pub struct FinalizedBatch {
+    pub msg: Vec<u8>,
+    pub str: Vec<u8>,
+}
+
+impl PreparedBatch for FinalizedBatch {
+    fn msg(&self) -> &[u8] {
+        &self.msg
+    }
+    fn str(&self) -> &[u8] {
+        &self.str
+    }
+}
+
+impl<'a> PreparedBatch for &'a FinalizedBatch {
+    fn msg(&self) -> &[u8] {
+        &self.msg
+    }
+    fn str(&self) -> &[u8] {
+        &self.str
+    }
+}
+
+/// A batch of static operations ready to perform on the DOM.
+/// This is meant to be generated from FinalizedBatch from a macro.
+pub struct StaticBatch {
+    pub msg: &'static [u8],
+    pub str: &'static [u8],
+}
+
+impl PreparedBatch for StaticBatch {
+    fn msg(&self) -> &[u8] {
+        self.msg
+    }
+    fn str(&self) -> &[u8] {
+        self.str
+    }
+}
+
+impl<'a> PreparedBatch for &'a StaticBatch {
+    fn msg(&self) -> &[u8] {
+        self.msg
+    }
+    fn str(&self) -> &[u8] {
+        self.str
+    }
+}
+
+/// A batch of operations to perform on the DOM.
 pub struct Batch {
     pub(crate) msg: Vec<u8>,
     pub(crate) str_buf: Vec<u8>,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -8,7 +8,7 @@ use std::{fmt::Arguments, io::Write};
 use web_sys::Node;
 
 use crate::{
-    batch::{Batch, FinalizedBatch, Op},
+    batch::{Batch, Op, PreparedBatch},
     last_needs_memory, update_last_memory, work_last_created, ElementBuilder, IntoAttribue,
     IntoElement, JsInterpreter, MSG_METADATA_PTR, MSG_PTR_PTR, STR_LEN_PTR, STR_PTR_PTR,
 };
@@ -499,8 +499,8 @@ impl MsgChannel {
     /// // add the batch to the channel
     /// channel.run_batch(&batch.finalize());
     /// ```
-    pub fn run_batch(&mut self, batch: &FinalizedBatch) {
-        run_batch(&batch.msg, &batch.str);
+    pub fn run_batch(&mut self, batch: impl PreparedBatch) {
+        run_batch(batch.msg(), batch.str());
     }
 }
 


### PR DESCRIPTION
This allows creating static batches for use with macros. This is can be used to remove the overhead of the Vec internal to the dynamic batch.